### PR TITLE
Schema registry cache invalidation

### DIFF
--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -24,9 +24,11 @@ const (
 	subject           = "/subjects"
 	subjects          = subject + "/%s"
 	subjectsNormalize = subject + "/%s?normalize=%t"
+	subjectsDelete    = subjects + "?permanent=%t"
 	version           = subjects + "/versions"
 	versionNormalize  = subjects + "/versions?normalize=%t"
 	versions          = version + "/%v"
+	versionsDelete    = versions + "?permanent=%t"
 	compatibility     = "/compatibility" + versions
 	config            = "/config"
 	subjectConfig     = config + "/%s"

--- a/schemaregistry/test/avro/advanced-2.avsc
+++ b/schemaregistry/test/avro/advanced-2.avsc
@@ -1,0 +1,82 @@
+{
+   "type":"record",
+   "name":"TestRecord",
+   "fields":[
+      {
+         "name":"value",
+         "type":"int"
+      },
+      {
+         "name":"defval1",
+         "type":"int",
+         "default":1234
+      },
+      {
+         "name":"defval2",
+         "type":"boolean",
+         "default":true
+      },
+      {
+         "name":"defval3",
+         "type":"double",
+         "default":567.89
+      },
+      {
+         "name":"defval4",
+         "type":"long",
+         "default":2345
+      },
+      {
+         "name":"union",
+         "type":[ {
+		    "name":"union1",
+			"type":"string"
+         },
+         {
+            "name":"union2",
+            "type":"boolean"
+         },
+         {
+            "name":"union3",
+            "type":"int"
+         }],
+         "default":"null"
+	  },
+      {
+         "name":"rec",
+         "type":{
+            "type":"array",
+            "items":{
+               "type":"record",
+               "name":"TestRecord2",
+               "fields":[
+                  {
+                     "name":"stringValue",
+                     "type":"string"
+                  },
+                  {
+                     "name":"intValue",
+                     "type":"int"
+                  },
+                  {
+                     "name" : "fruits",
+                     "type" : {
+                        "type" : "enum",
+                        "name" : "FruitNames",
+                        "symbols" : [ "apple", "banana", "pear", "plum" ]
+                     }
+                  },
+                  {
+                     "name" : "nullableStringValue",
+                     "type" : [
+                        "null",
+                        "string"
+                     ],
+                     "default": null
+                  }
+               ]
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
I've added support for the permanent parameter and some tests and a fix for the case where a single version is deleted, in that case the call to GetID should return no found too, like when called without cache.

In the real implementation all the deletes are treated as permanent regarding to the cache. In the mocked one soft deletes are handled to emulate the SR behavior.